### PR TITLE
Fix deprecated `std.mem.split`

### DIFF
--- a/jwt.zig
+++ b/jwt.zig
@@ -173,7 +173,7 @@ pub fn validateMessage(allocator: std.mem.Allocator, comptime expectedAlg: Algor
             // validating a JWS.  Let the Message be the result of base64url
             // decoding the JWS Payload.
             .JWS => {
-                var section_iter = std.mem.split(u8, tokenText, ".");
+                var section_iter = std.mem.splitScalar(u8, tokenText, '.');
                 std.debug.assert(section_iter.next() != null);
                 const payload_base64 = section_iter.next().?;
                 const signature_base64 = section_iter.rest();


### PR DESCRIPTION
`std.mem.split` is deprecated in zig 0.13.0, so it needs to be changed to `std.mem.splitScalar`, for programs to work